### PR TITLE
bugfix: add RBAC rule so service account can watch and list pods

### DIFF
--- a/charts/brigade-gitlab-gateway/templates/gateway-gitlab-role.yaml
+++ b/charts/brigade-gitlab-gateway/templates/gateway-gitlab-role.yaml
@@ -24,6 +24,9 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: [list", "watch"]
 ---
 kind: RoleBinding
 apiVersion: {{ template "brigade.rbac.version" }}


### PR DESCRIPTION
As mentioned in #3, this small adjustment should fix issue with pods listing. This is basically the same Rule as for official Github GW. 

```
E1111 08:33:21.181850       5 reflector.go:205] github.com/lukepatrick/brigade-gitlab-gateway/vendor/github.com/Azure/brigade/pkg/storage/kube/apicache/liststore.go:36: Failed to list *v1.Pod: pods is forbidden: User "system:serviceaccount:default:gl-gw-brigade-gitlab-gateway" cannot list pods in the namespace "default"
```

Tested with GKE / 1.9.7-gke.7.